### PR TITLE
Node.js 16.17.0 and yarn support

### DIFF
--- a/CodeApp/HelperFunctions/node.swift
+++ b/CodeApp/HelperFunctions/node.swift
@@ -107,7 +107,7 @@ public func node(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<In
     let args = convertCArguments(argc: argc, argv: argv)
 
     if args?.count == 1 {
-        fputs("Welcome to Node.js v16.14.2. \nREPL is unavailable in Code App.\n", thread_stderr)
+        fputs("Welcome to Node.js v16.17.0. \nREPL is unavailable in Code App.\n", thread_stderr)
         return 1
     }
 

--- a/downloadFrameworks.sh
+++ b/downloadFrameworks.sh
@@ -51,8 +51,8 @@ done
 # Node.js
 mkdir -p NodeJS
 cd NodeJS
-curl -OL https://github.com/1Conan/nodejs-mobile/releases/download/nodejs-v16.14.2-mobile-v0.4.0/NodeMobile.xcframework.zip
-unzip -q NodeMobile.xcframework.zip -d NodeMobile.xcframework
+curl -OL https://github.com/1Conan/nodejs-mobile/releases/download/v16.16.0-ios/NodeMobile.xcframework.zip
+unzip -q NodeMobile.xcframework.zip
 rm -f NodeMobile.xcframework.zip
 cd ..
 

--- a/downloadFrameworks.sh
+++ b/downloadFrameworks.sh
@@ -51,7 +51,7 @@ done
 # Node.js
 mkdir -p NodeJS
 cd NodeJS
-curl -OL https://github.com/1Conan/nodejs-mobile/releases/download/v16.16.0-ios/NodeMobile.xcframework.zip
+curl -OL https://github.com/1Conan/nodejs-mobile/releases/download/v16.17.0-ios/NodeMobile.xcframework.zip
 unzip -q NodeMobile.xcframework.zip
 rm -f NodeMobile.xcframework.zip
 cd ..

--- a/extension/ActionRequestHandler.swift
+++ b/extension/ActionRequestHandler.swift
@@ -99,7 +99,10 @@ class ActionRequestHandler: NSObject, NSExtensionRequestHandling {
         setenv("npm_config_prefix", sharedURL.appendingPathComponent("lib").path, 1)
         setenv("npm_config_cache", FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.path, 1)
         setenv("npm_config_userconfig", FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(".npmrc").path, 1)
-        
+        setenv("COREPACK_HOME", sharedURL.appendingPathComponent("corepack").path, 1)
+        setenv("TMPDIR", FileManager.default.temporaryDirectory.path, 1)
+        setenv("YARN_CACHE_FOLDER", FileManager.default.temporaryDirectory.path, 1)
+        setenv("HOME", sharedURL.path, 1)
         // Do not call super in an Action extension with no user interface
         self.extensionContext = context
         


### PR DESCRIPTION
NodeJS's `fs.copyFile()` always fail and causes yarn to not work properly. Changes need to be made in https://github.com/1Conan/nodejs-mobile.