### PR TITLE
Show delete confirmation before trashing files

### DIFF
--- a/CodeApp/Localization/de.lproj/Localizable.strings
+++ b/CodeApp/Localization/de.lproj/Localizable.strings
@@ -377,6 +377,7 @@
 "common.dont_save" = "Nicht speichern";
 "common.cancel" = "Abbrechen";
 "common.revert" = "Rückgängig machen";
+"common.delete" = "Löschen";
 
 "notification.source" = "Quelle: %@";
 
@@ -420,6 +421,7 @@
 "file.copy" = "Kopieren nach..";
 "file.download" = "Herunterladen auf..";
 "file.confirm_save %@" = "Möchten Sie die Änderungen an %@ speichern?";
+"file.confirm_delete %@" = "Möchten Sie %@ wirklich löschen?";
 
 "actions.new_window" = "Neues Fenster";
 

--- a/CodeApp/Localization/en.lproj/Localizable.strings
+++ b/CodeApp/Localization/en.lproj/Localizable.strings
@@ -268,6 +268,7 @@ are licensed under [BSD-3-Clause License](https://en.wikipedia.org/wiki/BSD_lice
 "common.dont_save" = "Don't Save";
 "common.cancel" = "Cancel";
 "common.revert" = "Revert";
+"common.delete" = "Delete";
 
 "notification.source" = "Source: %@";
 
@@ -311,6 +312,7 @@ are licensed under [BSD-3-Clause License](https://en.wikipedia.org/wiki/BSD_lice
 "file.copy" = "Copy to..";
 "file.download" = "Download to..";
 "file.confirm_save %@" = "Do you want to save the changes made to %@?";
+"file.confirm_delete %@" = "Are you sure you want to delete %@?";
 
 "actions.new_window" = "New Window";
 

--- a/CodeApp/Localization/ja.lproj/Localizable.strings
+++ b/CodeApp/Localization/ja.lproj/Localizable.strings
@@ -378,6 +378,7 @@
 "common.dont_save" = "保存しない";
 "common.cancel" = "キャンセル";
 "common.revert" = "元に戻す";
+"common.delete" = "削除";
 
 "notification.source" = "Source: %@";
 
@@ -421,6 +422,7 @@
 "file.copy" = "コピー..";
 "file.download" = "ダウンロード..";
 "file.confirm_save %@" = "%@ に加えた変更を保存しますか?";
+"file.confirm_delete %@" = "%@ を削除しますか?";
 
 "actions.new_window" = "新しいウィンドウ";
 

--- a/CodeApp/Localization/ko.lproj/Localizable.strings
+++ b/CodeApp/Localization/ko.lproj/Localizable.strings
@@ -369,7 +369,7 @@
 "Enable spell check in text files" = "텍스트 파일에서 맞춤법 검사 활성화";
 "Spell checking on content changed" = "변경한 내용에 대해 맞춤법 검사";
 
-"common.configure" = "";
+"common.configure" = "설정";
 "common.open_folder" = "폴더 열기";
 "common.compare" = "비교";
 "common.overwrite" = "덮어쓰기";
@@ -377,6 +377,7 @@
 "common.dont_save" = "저장하지 않음";
 "common.cancel" = "취소";
 "common.revert" = "되돌리기";
+"common.delete" = "삭제";
 
 "notification.source" = "원천: %@";
 
@@ -419,7 +420,8 @@
 
 "file.copy" = "에게 복사..";
 "file.download" = "다운로드..";
-"file.confirm_save %@" = "파일을 저장하시겠습니까?";
+"file.confirm_save %@" = "%@을 저장하시겠습니까?";
+"file.confirm_delete %@" = "%@을 삭제하시겠습니까?";
 
 "actions.new_window" = "새창";
 

--- a/CodeApp/Localization/zh-Hans.lproj/Localizable.strings
+++ b/CodeApp/Localization/zh-Hans.lproj/Localizable.strings
@@ -368,6 +368,7 @@
 "common.dont_save" = "不保存";
 "common.cancel" = "取消";
 "common.revert" = "还原";
+"common.delete" = "删除";
 
 "notification.source" = "来源: %@";
 
@@ -411,6 +412,7 @@
 "file.copy" = "复制到..";
 "file.download" = "下载到..";
 "file.confirm_save %@" = "是否要保存 %@？";
+"file.confirm_delete %@" = "你确定要删除 %@ 吗？";
 
 "actions.new_window" = "新窗口";
 

--- a/CodeApp/Managers/MainApp.swift
+++ b/CodeApp/Managers/MainApp.swift
@@ -308,17 +308,26 @@ class MainApp: ObservableObject {
     }
 
     func trashItem(url: URL) {
-        workSpaceStorage.removeItem(at: url) { error in
-            if let error = error {
-                self.notificationManager.showErrorMessage(error.localizedDescription)
-                return
-            }
-            if let editorToTrash = self.textEditors.first(where: { $0.url == url }) {
-                Task { @MainActor in
-                    self.closeEditor(editor: editorToTrash)
+        alertManager.showAlert(
+            title: "file.confirm_delete \(url.lastPathComponent)",
+            content: AnyView(
+                Group {
+                    Button("common.delete", role: .destructive) {
+                        self.workSpaceStorage.removeItem(at: url) { error in
+                            if let error = error {
+                                self.notificationManager.showErrorMessage(error.localizedDescription)
+                                return
+                            }
+                            if let editorToTrash = self.textEditors.first(where: { $0.url == url }) {
+                                Task { @MainActor in
+                                    self.closeEditor(editor: editorToTrash)
+                                }
+                            }
+                        }
+                    }
+                    Button("common.cancel", role: .cancel) {}
                 }
-            }
-        }
+            ))
     }
 
     func decodeStringData(data: Data) throws -> (String, String.Encoding) {


### PR DESCRIPTION
This is important, especially for folders with content, because it cannot be undone (without git, but we can’t ever assume git is used by every folder).