### PR TITLE
Add Esc/Del and Ctrl/Alt modifier support to terminal toolbar

### DIFF
--- a/CodeApp/Managers/TerminalInstance.swift
+++ b/CodeApp/Managers/TerminalInstance.swift
@@ -540,7 +540,7 @@ extension TerminalInstance: WKUIDelegate {
 extension TerminalInstance {
     func type(text: String) {
         guard let base64 = text.base64Encoded() else { return }
-        executeScript("term.input(base64ToString(`\(base64)`))")
+        executeScript("inputWithModifiers(base64ToString(`\(base64)`))")
     }
 
     func moveCursor(codeSequence: String) {
@@ -551,8 +551,16 @@ extension TerminalInstance {
         executeScript("setControlActive(\(active), \(generation))")
     }
 
+    func setControlLocked(_ locked: Bool) {
+        executeScript("setControlLocked(\(locked))")
+    }
+
     func setAltActive(_ active: Bool, generation: Int) {
         executeScript("setAltActive(\(active), \(generation))")
+    }
+
+    func setAltLocked(_ locked: Bool) {
+        executeScript("setAltLocked(\(locked))")
     }
 }
 

--- a/CodeApp/Views/TerminalKeyboardToolbar.swift
+++ b/CodeApp/Views/TerminalKeyboardToolbar.swift
@@ -13,25 +13,97 @@ struct TerminalKeyboardToolBar: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @State var pasteBoardHasContent = false
     @State var controlActive = false
+    @State var controlLocked = false
+    @State var controlLastTapTime: Date?
     @State var controlGeneration = 0
     @State var altActive = false
+    @State var altLocked = false
+    @State var altLastTapTime: Date?
     @State var altGeneration = 0
+
+    private let doubleTapInterval: TimeInterval = 0.3
 
     private func resetModifierStates() {
         controlActive = false
+        controlLocked = false
         App.terminalInstance.setControlActive(false, generation: controlGeneration)
+        App.terminalInstance.setControlLocked(false)
         altActive = false
+        altLocked = false
         App.terminalInstance.setAltActive(false, generation: altGeneration)
+        App.terminalInstance.setAltLocked(false)
+    }
+
+    private func resetUnlockedModifiers() {
+        // Reset modifiers only if they are not locked
+        if !controlLocked {
+            controlActive = false
+            App.terminalInstance.setControlActive(false, generation: controlGeneration)
+        }
+        if !altLocked {
+            altActive = false
+            App.terminalInstance.setAltActive(false, generation: altGeneration)
+        }
+    }
+
+    private func handleControlTap() {
+        let now = Date()
+        let isDoubleTap =
+            controlLastTapTime.map { now.timeIntervalSince($0) < doubleTapInterval } ?? false
+        controlLastTapTime = now
+
+        if controlLocked {
+            // Single tap while locked: unlock and deactivate
+            controlLocked = false
+            controlActive = false
+            controlGeneration += 1
+            App.terminalInstance.setControlLocked(false)
+            App.terminalInstance.setControlActive(false, generation: controlGeneration)
+        } else if isDoubleTap && controlActive {
+            // Double tap while active: lock
+            controlLocked = true
+            App.terminalInstance.setControlLocked(true)
+        } else {
+            // Single tap: toggle active state
+            controlActive.toggle()
+            controlGeneration += 1
+            App.terminalInstance.setControlActive(controlActive, generation: controlGeneration)
+        }
+    }
+
+    private func handleAltTap() {
+        let now = Date()
+        let isDoubleTap =
+            altLastTapTime.map { now.timeIntervalSince($0) < doubleTapInterval } ?? false
+        altLastTapTime = now
+
+        if altLocked {
+            // Single tap while locked: unlock and deactivate
+            altLocked = false
+            altActive = false
+            altGeneration += 1
+            App.terminalInstance.setAltLocked(false)
+            App.terminalInstance.setAltActive(false, generation: altGeneration)
+        } else if isDoubleTap && altActive {
+            // Double tap while active: lock
+            altLocked = true
+            App.terminalInstance.setAltLocked(true)
+        } else {
+            // Single tap: toggle active state
+            altActive.toggle()
+            altGeneration += 1
+            App.terminalInstance.setAltActive(altActive, generation: altGeneration)
+        }
     }
 
     private func typeAndResetModifiers(text: String) {
         App.terminalInstance.type(text: text)
-        resetModifierStates()
+        resetUnlockedModifiers()
     }
 
     private func moveCursorAndResetModifiers(codeSequence: String) {
         App.terminalInstance.moveCursor(codeSequence: codeSequence)
-        resetModifierStates()
+        resetUnlockedModifiers()
     }
 
     var body: some View {
@@ -66,10 +138,7 @@ struct TerminalKeyboardToolBar: View {
                     })
                 Button(
                     action: {
-                        controlActive.toggle()
-                        controlGeneration += 1
-                        App.terminalInstance.setControlActive(
-                            controlActive, generation: controlGeneration)
+                        handleControlTap()
                     },
                     label: {
                         Text("Ctrl")
@@ -78,16 +147,18 @@ struct TerminalKeyboardToolBar: View {
                                 controlActive ? Color.accentColor.opacity(0.3) : Color.clear
                             )
                             .cornerRadius(4)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(Color.accentColor, lineWidth: controlLocked ? 2 : 0)
+                            )
                     }
                 )
                 .accessibilityLabel("Control")
-                .accessibilityValue(controlActive ? "Active" : "Inactive")
+                .accessibilityValue(
+                    controlLocked ? "Locked" : (controlActive ? "Active" : "Inactive"))
                 Button(
                     action: {
-                        altActive.toggle()
-                        altGeneration += 1
-                        App.terminalInstance.setAltActive(
-                            altActive, generation: altGeneration)
+                        handleAltTap()
                     },
                     label: {
                         Text("Alt")
@@ -96,10 +167,14 @@ struct TerminalKeyboardToolBar: View {
                                 altActive ? Color.accentColor.opacity(0.3) : Color.clear
                             )
                             .cornerRadius(4)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(Color.accentColor, lineWidth: altLocked ? 2 : 0)
+                            )
                     }
                 )
                 .accessibilityLabel("Alt")
-                .accessibilityValue(altActive ? "Active" : "Inactive")
+                .accessibilityValue(altLocked ? "Locked" : (altActive ? "Active" : "Inactive"))
                 Button(
                     action: {
                         typeAndResetModifiers(text: "\u{1b}[3~")

--- a/Dependencies/terminal.bundle/index.html
+++ b/Dependencies/terminal.bundle/index.html
@@ -155,8 +155,10 @@
       localEcho.addAutocompleteHandler(autocompleteCommonFiles);
 
       var controlActive = false;
+      var controlLocked = false;
       var controlGeneration = 0;
       var altActive = false;
+      var altLocked = false;
       var altGeneration = 0;
 
       function setControlActive(active, generation) {
@@ -164,9 +166,17 @@
         controlGeneration = generation;
       }
 
+      function setControlLocked(locked) {
+        controlLocked = locked;
+      }
+
       function setAltActive(active, generation) {
         altActive = active;
         altGeneration = generation;
+      }
+
+      function setAltLocked(locked) {
+        altLocked = locked;
       }
 
       function shouldApplyModifierToCsi(final, params) {
@@ -245,7 +255,7 @@
       }
 
       function applyModifierStates(data) {
-        // Capture which modifiers are active before resetting
+        // Capture which modifiers are active before potentially resetting
         var wasControlActive = controlActive;
         var wasAltActive = altActive;
 
@@ -253,15 +263,15 @@
           return data;
         }
 
-        // Reset all active modifiers and notify Swift
-        if (wasControlActive) {
+        // Reset modifiers only if not locked, and notify Swift
+        if (wasControlActive && !controlLocked) {
           controlActive = false;
           window.webkit.messageHandlers.toggleMessageHandler2.postMessage({
             Event: "ControlReset",
             Generation: controlGeneration,
           });
         }
-        if (wasAltActive) {
+        if (wasAltActive && !altLocked) {
           altActive = false;
           window.webkit.messageHandlers.toggleMessageHandler2.postMessage({
             Event: "AltReset",


### PR DESCRIPTION
## Summary

- Add Esc and Del buttons to the terminal keyboard toolbar.
- Add Ctrl/Alt modifier toggles with active-state UI and generation tracking.
- Apply modifier logic to terminal input (single chars, CSI/SS3 sequences) in the JS terminal layer.
- Sync modifier resets between JS and Swift via notifications; reset modifiers after input or blur.

## Changes

Terminal keyboard toolbar (TerminalKeyboardToolbar.swift):
- Add controlActive/altActive state plus generation counters.
- Add helpers to send input or cursor moves and then reset modifier state, plus a dedicated reset function.
- Insert Esc, Ctrl, Alt, and Del buttons with accessibility labels and active-state highlighting for modifiers.
- Route paste/tab/arrow actions through the modifier-reset helpers; reset modifiers on blur.
- Listen for terminalControlReset/terminalAltReset notifications to clear the UI state when JS resets.

Terminal JavaScript (terminal.bundle/index.html):
- Track modifier state and generation, expose setControlActive/setAltActive.
- Apply Control/Alt to input, including CSI/SS3 sequences, and avoid applying modifiers to non-modifiable sequences.
- Reset modifier state after use and notify Swift with generation-aware reset events.
- Apply modifier processing inside term.onData before posting input to Swift.

Terminal instance (TerminalInstance.swift):
- Handle ControlReset/AltReset messages from JS and post notifications with generation info.
- Add methods to set Control/Alt state in the JS runtime.
- Add terminalControlReset/terminalAltReset notification names.