### PR TITLE
fix: remove pkg_resources fallback for setuptools 82+ compatibility

### DIFF
--- a/LanguageResources/Library/bin/cygdb
+++ b/LanguageResources/Library/bin/cygdb
@@ -6,13 +6,7 @@ import sys
 # for compatibility with easy_install; see #2198
 __requires__ = 'Cython==0.29.21'
 
-try:
-    from importlib.metadata import distribution
-except ImportError:
-    try:
-        from importlib_metadata import distribution
-    except ImportError:
-        from pkg_resources import load_entry_point
+from importlib.metadata import distribution
 
 
 def importlib_load_entry_point(spec, group, name):

--- a/LanguageResources/Library/bin/cython
+++ b/LanguageResources/Library/bin/cython
@@ -6,13 +6,7 @@ import sys
 # for compatibility with easy_install; see #2198
 __requires__ = 'Cython==0.29.21'
 
-try:
-    from importlib.metadata import distribution
-except ImportError:
-    try:
-        from importlib_metadata import distribution
-    except ImportError:
-        from pkg_resources import load_entry_point
+from importlib.metadata import distribution
 
 
 def importlib_load_entry_point(spec, group, name):

--- a/LanguageResources/Library/bin/cythonize
+++ b/LanguageResources/Library/bin/cythonize
@@ -6,13 +6,7 @@ import sys
 # for compatibility with easy_install; see #2198
 __requires__ = 'Cython==0.29.21'
 
-try:
-    from importlib.metadata import distribution
-except ImportError:
-    try:
-        from importlib_metadata import distribution
-    except ImportError:
-        from pkg_resources import load_entry_point
+from importlib.metadata import distribution
 
 
 def importlib_load_entry_point(spec, group, name):


### PR DESCRIPTION
## Summary

Remove deprecated pkg_resources fallback from Cython entry-point scripts for setuptools 82+ compatibility.

## Root Cause

The scripts use a three-level fallback for loading entry points. Since importlib.metadata is in Python stdlib (3.8+), the try/except block is dead code. On setuptools 82+, the pkg_resources import fails with ModuleNotFoundError.

## Fix

Replace the try/except block with a direct import of importlib.metadata.distribution.

## Files Changed

- LanguageResources/Library/bin/cygdb
- LanguageResources/Library/bin/cython
- LanguageResources/Library/bin/cythonize

Fixes #ISSUE